### PR TITLE
Ahora sale cuando se escribe "exit" en el cliente

### DIFF
--- a/Cliente/src/Cliente.c
+++ b/Cliente/src/Cliente.c
@@ -75,7 +75,7 @@ int main(){
 
 		fill_package(&package, &username);						// Completamos el package, que contendra los datos del usuario y los datos del mensaje que vamos a enviar.
 
-		if(!strcmp(package.message, "exit")) enviar = 1;		// Chequeamos si el usuario quiere salir.
+		if(!strcmp(package.message, "exit\n")) enviar = 0;		// Chequeamos si el usuario quiere salir.
 
 		if(enviar) {
 			serializedPackage = serializarOperandos(&package);	// Ver: ¿Por que serializacion dinamica? En el comentario de la definicion de la funcion.


### PR DESCRIPTION
Estaba mal el `strcmp()` del comando exit.
`fgets()` devuelve un `\n` al final
`enviar` se debe setear a 0 para salir.